### PR TITLE
new LLRF->BSA/MPS ICD increase permits from 16-bit digital bus to 32-bit

### DIFF
--- a/firmware/common/AppCommon/BsaMpsMsgRx/BsaMpsMsgRxCombine.vhd
+++ b/firmware/common/AppCommon/BsaMpsMsgRx/BsaMpsMsgRxCombine.vhd
@@ -261,10 +261,6 @@ begin
             -- Update the data field
             for i in 11 downto 0 loop
 
-               -------------------------------------------------
-               -- TODO: Adding new mapping (waiting for Berkley)
-               -------------------------------------------------
-
                -- Link 0
                v.diagnosticBus.sevr(i+0)(0)           := remoteMsg(0).bsaSevr(i)(0);  -- Only Mapping bsaSevr's LSB
                v.diagnosticBus.data(i+0)(15 downto 0) := remoteMsg(0).bsaQuantity(i)(31 downto 16);  -- Only Mapping upper 16-bit from bsaQuantity

--- a/firmware/common/AppCommon/BsaMpsMsgRx/BsaMpsMsgRxCombine.vhd
+++ b/firmware/common/AppCommon/BsaMpsMsgRx/BsaMpsMsgRxCombine.vhd
@@ -245,7 +245,9 @@ begin
                -- Update the MPS message
                v.diagnosticBus.sevr(30) := r.sevr(i) or v.diagnosticBus.sevr(30);
                if (r.sevr(i) = "00") then
-                  v.diagnosticBus.data(30)((4*i)+3 downto 4*i) := remoteMsg(i).mpsPermit;
+                  for j in 3 downto 0 loop
+                     v.diagnosticBus.data(30)((8*i)+(2*j)+1 downto (8*i)+(2*j)) := remoteMsg(i).mpsPermit(j);
+                  end loop;
                end if;
 
                -- Check for drop due to misalignment

--- a/firmware/common/AppCommon/BsaMpsMsgRx/BsaMpsMsgRxCombine.vhd
+++ b/firmware/common/AppCommon/BsaMpsMsgRx/BsaMpsMsgRxCombine.vhd
@@ -259,30 +259,23 @@ begin
             end loop;
 
             -- Update the data field
-            for i in 3 downto 0 loop
+            for i in 11 downto 0 loop
 
-               ------------------------------------------------------------------------------
-               -- Refer to "LCLSII LLRF link to BSA/MPS" ICD for where this mapping came from
-               ------------------------------------------------------------------------------
+               -- Link 0
+               v.diagnosticBus.sevr(i+0)(0)           := remoteMsg(0).bsaSevr(i)(0);  -- Only Mapping bsaSevr's LSB
+               v.diagnosticBus.data(i+0)(15 downto 0) := remoteMsg(0).bsaQuantity(i)(31 downto 16);  -- Only Mapping upper 16-bit from bsaQuantity
 
-               for j in 5 downto 0 loop
-                  v.diagnosticBus.sevr(6*i+j)(1) := remoteMsg(i).bsaSevr(j)(1);
-                  v.diagnosticBus.sevr(6*i+j)(0) := remoteMsg(i).bsaSevr(j)(0);
-               end loop;
+               -- Link 1
+               v.diagnosticBus.sevr(i+0)(1)            := remoteMsg(1).bsaSevr(i)(0);  -- Only Mapping bsaSevr's LSB
+               v.diagnosticBus.data(i+0)(31 downto 16) := remoteMsg(1).bsaQuantity(i)(31 downto 16);  -- Only Mapping upper 16-bit from bsaQuantity
 
-               v.diagnosticBus.data(6*i+0)(31 downto 16) := remoteMsg(i).bsaQuantity(3)(31 downto 16);  -- Only Mapping upper 16-bit from bsaQuantity
-               v.diagnosticBus.data(6*i+1)(31 downto 16) := remoteMsg(i).bsaQuantity(7)(31 downto 16);  -- Only Mapping upper 16-bit from bsaQuantity
-               v.diagnosticBus.data(6*i+2)(31 downto 16) := remoteMsg(i).bsaQuantity(11)(31 downto 16);  -- Only Mapping upper 16-bit from bsaQuantity
-               v.diagnosticBus.data(6*i+3)(31 downto 16) := remoteMsg(i).bsaQuantity(15)(31 downto 16);  -- Only Mapping upper 16-bit from bsaQuantity
-               v.diagnosticBus.data(6*i+4)(31 downto 16) := remoteMsg(i).bsaQuantity(19)(31 downto 16);  -- Only Mapping upper 16-bit from bsaQuantity
-               v.diagnosticBus.data(6*i+5)(31 downto 16) := remoteMsg(i).bsaQuantity(23)(31 downto 16);  -- Only Mapping upper 16-bit from bsaQuantity
+               -- Link 2
+               v.diagnosticBus.sevr(i+12)(0)           := remoteMsg(2).bsaSevr(i)(0);  -- Only Mapping bsaSevr's LSB
+               v.diagnosticBus.data(i+12)(15 downto 0) := remoteMsg(2).bsaQuantity(i)(31 downto 16);  -- Only Mapping upper 16-bit from bsaQuantity
 
-               v.diagnosticBus.data(6*i+0)(15 downto 0) := remoteMsg(i).bsaQuantity(1)(31 downto 16);  -- Only Mapping upper 16-bit from bsaQuantity
-               v.diagnosticBus.data(6*i+1)(15 downto 0) := remoteMsg(i).bsaQuantity(5)(31 downto 16);  -- Only Mapping upper 16-bit from bsaQuantity
-               v.diagnosticBus.data(6*i+2)(15 downto 0) := remoteMsg(i).bsaQuantity(9)(31 downto 16);  -- Only Mapping upper 16-bit from bsaQuantity
-               v.diagnosticBus.data(6*i+3)(15 downto 0) := remoteMsg(i).bsaQuantity(13)(31 downto 16);  -- Only Mapping upper 16-bit from bsaQuantity
-               v.diagnosticBus.data(6*i+4)(15 downto 0) := remoteMsg(i).bsaQuantity(17)(31 downto 16);  -- Only Mapping upper 16-bit from bsaQuantity
-               v.diagnosticBus.data(6*i+5)(15 downto 0) := remoteMsg(i).bsaQuantity(21)(31 downto 16);  -- Only Mapping upper 16-bit from bsaQuantity
+               -- Link 3
+               v.diagnosticBus.sevr(i+12)(1)            := remoteMsg(3).bsaSevr(i)(0);  -- Only Mapping bsaSevr's LSB
+               v.diagnosticBus.data(i+12)(31 downto 16) := remoteMsg(3).bsaQuantity(i)(31 downto 16);  -- Only Mapping upper 16-bit from bsaQuantity
 
             end loop;
 

--- a/firmware/common/AppCommon/BsaMpsMsgRx/BsaMpsMsgRxCombine.vhd
+++ b/firmware/common/AppCommon/BsaMpsMsgRx/BsaMpsMsgRxCombine.vhd
@@ -259,23 +259,30 @@ begin
             end loop;
 
             -- Update the data field
-            for i in 11 downto 0 loop
+            for i in 3 downto 0 loop
 
-               -- Link 0
-               v.diagnosticBus.sevr(i+0)(0)           := remoteMsg(0).bsaSevr(i)(0);  -- Only Mapping bsaSevr's LSB
-               v.diagnosticBus.data(i+0)(15 downto 0) := remoteMsg(0).bsaQuantity(i)(31 downto 16);  -- Only Mapping upper 16-bit from bsaQuantity
+               ------------------------------------------------------------------------------
+               -- Refer to "LCLSII LLRF link to BSA/MPS" ICD for where this mapping came from
+               ------------------------------------------------------------------------------
 
-               -- Link 1
-               v.diagnosticBus.sevr(i+0)(1)            := remoteMsg(1).bsaSevr(i)(0);  -- Only Mapping bsaSevr's LSB
-               v.diagnosticBus.data(i+0)(31 downto 16) := remoteMsg(1).bsaQuantity(i)(31 downto 16);  -- Only Mapping upper 16-bit from bsaQuantity
+               for j in 5 downto 0 loop
+                  v.diagnosticBus.sevr(6*i+j)(1) := remoteMsg(i).bsaSevr(j)(1);
+                  v.diagnosticBus.sevr(6*i+j)(0) := remoteMsg(i).bsaSevr(j)(0);
+               end loop;
 
-               -- Link 2
-               v.diagnosticBus.sevr(i+12)(0)           := remoteMsg(2).bsaSevr(i)(0);  -- Only Mapping bsaSevr's LSB
-               v.diagnosticBus.data(i+12)(15 downto 0) := remoteMsg(2).bsaQuantity(i)(31 downto 16);  -- Only Mapping upper 16-bit from bsaQuantity
+               v.diagnosticBus.data(6*i+0)(31 downto 16) := remoteMsg(i).bsaQuantity(3)(31 downto 16);  -- Only Mapping upper 16-bit from bsaQuantity
+               v.diagnosticBus.data(6*i+1)(31 downto 16) := remoteMsg(i).bsaQuantity(7)(31 downto 16);  -- Only Mapping upper 16-bit from bsaQuantity
+               v.diagnosticBus.data(6*i+2)(31 downto 16) := remoteMsg(i).bsaQuantity(11)(31 downto 16);  -- Only Mapping upper 16-bit from bsaQuantity
+               v.diagnosticBus.data(6*i+3)(31 downto 16) := remoteMsg(i).bsaQuantity(15)(31 downto 16);  -- Only Mapping upper 16-bit from bsaQuantity
+               v.diagnosticBus.data(6*i+4)(31 downto 16) := remoteMsg(i).bsaQuantity(19)(31 downto 16);  -- Only Mapping upper 16-bit from bsaQuantity
+               v.diagnosticBus.data(6*i+5)(31 downto 16) := remoteMsg(i).bsaQuantity(23)(31 downto 16);  -- Only Mapping upper 16-bit from bsaQuantity
 
-               -- Link 3
-               v.diagnosticBus.sevr(i+12)(1)            := remoteMsg(3).bsaSevr(i)(0);  -- Only Mapping bsaSevr's LSB
-               v.diagnosticBus.data(i+12)(31 downto 16) := remoteMsg(3).bsaQuantity(i)(31 downto 16);  -- Only Mapping upper 16-bit from bsaQuantity
+               v.diagnosticBus.data(6*i+0)(15 downto 0) := remoteMsg(i).bsaQuantity(1)(31 downto 16);  -- Only Mapping upper 16-bit from bsaQuantity
+               v.diagnosticBus.data(6*i+1)(15 downto 0) := remoteMsg(i).bsaQuantity(5)(31 downto 16);  -- Only Mapping upper 16-bit from bsaQuantity
+               v.diagnosticBus.data(6*i+2)(15 downto 0) := remoteMsg(i).bsaQuantity(9)(31 downto 16);  -- Only Mapping upper 16-bit from bsaQuantity
+               v.diagnosticBus.data(6*i+3)(15 downto 0) := remoteMsg(i).bsaQuantity(13)(31 downto 16);  -- Only Mapping upper 16-bit from bsaQuantity
+               v.diagnosticBus.data(6*i+4)(15 downto 0) := remoteMsg(i).bsaQuantity(17)(31 downto 16);  -- Only Mapping upper 16-bit from bsaQuantity
+               v.diagnosticBus.data(6*i+5)(15 downto 0) := remoteMsg(i).bsaQuantity(21)(31 downto 16);  -- Only Mapping upper 16-bit from bsaQuantity
 
             end loop;
 

--- a/firmware/common/AppCommon/BsaMpsMsgRx/BsaMpsMsgRxFramer.vhd
+++ b/firmware/common/AppCommon/BsaMpsMsgRx/BsaMpsMsgRxFramer.vhd
@@ -221,18 +221,19 @@ begin
             -- Check for valid data
             if (r.rxValid = '1') and (r.rxdataK = "00") then
                -- Forward the data to CRC
-               v.crcValid       := '1';
-               v.crcData        := r.rxData;
+               v.crcValid         := '1';
+               v.crcData          := r.rxData;
                -- Save the bus value
-               v.msg.mpsPermit  := r.rxData(3 downto 0);
-               v.msg.bsaSevr(0) := r.rxData(5 downto 4);
-               v.msg.bsaSevr(1) := r.rxData(7 downto 6);
-               v.msg.bsaSevr(2) := r.rxData(9 downto 8);
-               v.msg.bsaSevr(3) := r.rxData(11 downto 10);
-               v.msg.bsaSevr(4) := r.rxData(13 downto 12);
-               v.msg.bsaSevr(5) := r.rxData(15 downto 14);
+               v.msg.mpsPermit(0) := r.rxData(1 downto 0);
+               v.msg.mpsPermit(1) := r.rxData(3 downto 2);
+               v.msg.bsaSevr(0)   := r.rxData(5 downto 4);
+               v.msg.bsaSevr(1)   := r.rxData(7 downto 6);
+               v.msg.bsaSevr(2)   := r.rxData(9 downto 8);
+               v.msg.bsaSevr(3)   := r.rxData(11 downto 10);
+               v.msg.bsaSevr(4)   := r.rxData(13 downto 12);
+               v.msg.bsaSevr(5)   := r.rxData(15 downto 14);
                -- Next State
-               v.state          := BSA_SEVR_S;
+               v.state            := BSA_SEVR_S;
             else
                -- Next state
                v.state := IDLE_S;
@@ -242,18 +243,19 @@ begin
             -- Check for valid data
             if (r.rxValid = '1') and (r.rxdataK = "00") then
                -- Forward the data to CRC
-               v.crcValid        := '1';
-               v.crcData         := r.rxData;
+               v.crcValid         := '1';
+               v.crcData          := r.rxData;
                -- Save the bus value
-               -- Note: r.rxData(3 downto 0) not used and undefined
-               v.msg.bsaSevr(6)  := r.rxData(5 downto 4);
-               v.msg.bsaSevr(7)  := r.rxData(7 downto 6);
-               v.msg.bsaSevr(8)  := r.rxData(9 downto 8);
-               v.msg.bsaSevr(9)  := r.rxData(11 downto 10);
-               v.msg.bsaSevr(10) := r.rxData(13 downto 12);
-               v.msg.bsaSevr(11) := r.rxData(15 downto 14);
+               v.msg.mpsPermit(2) := r.rxData(1 downto 0);
+               v.msg.mpsPermit(3) := r.rxData(3 downto 2);
+               v.msg.bsaSevr(6)   := r.rxData(5 downto 4);
+               v.msg.bsaSevr(7)   := r.rxData(7 downto 6);
+               v.msg.bsaSevr(8)   := r.rxData(9 downto 8);
+               v.msg.bsaSevr(9)   := r.rxData(11 downto 10);
+               v.msg.bsaSevr(10)  := r.rxData(13 downto 12);
+               v.msg.bsaSevr(11)  := r.rxData(15 downto 14);
                -- Next State
-               v.state           := BSA_DATA_S;
+               v.state            := BSA_DATA_S;
             else
                -- Next state
                v.state := IDLE_S;

--- a/firmware/common/AppCommon/BsaMpsMsgRx/BsaMpsMsgRxFramerPkg.vhd
+++ b/firmware/common/AppCommon/BsaMpsMsgRx/BsaMpsMsgRxFramerPkg.vhd
@@ -21,17 +21,17 @@ use surf.StdRtlPkg.all;
 
 package BsaMpsMsgRxFramerPkg is
 
-   constant RX_MSG_FIFO_WIDTH_C : positive := 476;
+   constant RX_MSG_FIFO_WIDTH_C : positive := 480;
 
    type MsgType is record
-      mpsPermit   : slv(3 downto 0);
+      mpsPermit   : Slv2Array(3 downto 0);
       timeStamp   : slv(63 downto 0);
       bsaSevr     : Slv2Array(11 downto 0);
       bsaQuantity : Slv32Array(11 downto 0);
    end record MsgType;
    type MsgArray is array (natural range <>) of MsgType;
    constant MSG_INIT_C : MsgType := (
-      mpsPermit   => (others => '0'),
+      mpsPermit   => (others => (others => '0')),
       timeStamp   => (others => '0'),
       bsaSevr     => (others => (others => '0')),
       bsaQuantity => (others => (others => '0')));
@@ -59,11 +59,13 @@ package body BsaMpsMsgRxFramerPkg is
       retVar.timeStamp := dout(447 downto 384);
 
       -- Load the MPS permit
-      retVar.mpsPermit := dout(451 downto 448);
+      for i in 3 downto 0 loop
+         retVar.mpsPermit(i) := dout((i*2)+449 downto (i*2)+448);
+      end loop;
 
       -- Load the BSA Severity
       for i in 11 downto 0 loop
-         retVar.bsaSevr(i) := dout((i*2)+453 downto (i*2)+452);
+         retVar.bsaSevr(i) := dout((i*2)+457 downto (i*2)+456);
       end loop;
 
       return retVar;
@@ -85,11 +87,13 @@ package body BsaMpsMsgRxFramerPkg is
       retVar(447 downto 384) := msg.timeStamp;
 
       -- Load the MPS permit
-      retVar(451 downto 448) := msg.mpsPermit;
+      for i in 3 downto 0 loop
+         retVar((i*2)+449 downto (i*2)+448) := msg.mpsPermit(i);
+      end loop;
 
       -- Load the BSA Severity
       for i in 11 downto 0 loop
-         retVar((i*2)+453 downto (i*2)+452) := msg.bsaSevr(i);
+         retVar((i*2)+457 downto (i*2)+456) := msg.bsaSevr(i);
       end loop;
 
       return retVar;

--- a/firmware/common/AppCommon/BsaMpsMsgRx/BsaMpsMsgRxFramerReg.vhd
+++ b/firmware/common/AppCommon/BsaMpsMsgRx/BsaMpsMsgRxFramerReg.vhd
@@ -154,7 +154,10 @@ begin
          axiSlaveRegisterR(axilEp, toSlv(2048+(1*64)+4*i, 12), 0, remoteMsg.bsaSevr(i));
       end loop;
 
-      axiSlaveRegisterR(axilEp, x"900", 0, remoteMsg.mpsPermit);
+      for i in 3 downto 0 loop
+         axiSlaveRegisterR(axilEp, x"900", (2*i), remoteMsg.mpsPermit(i));
+      end loop;
+
       axiSlaveRegisterR(axilEp, x"910", 0, remoteMsg.timeStamp);
 
       -- Closeout the transaction

--- a/firmware/common/AppCommon/yaml/BsaMpsMsgRxCore.yaml
+++ b/firmware/common/AppCommon/yaml/BsaMpsMsgRxCore.yaml
@@ -336,7 +336,7 @@ BsaMpsMsgRxCore: &BsaMpsMsgRxCore
       class: IntField
       name: MpsPermit
       mode: RO
-      sizeBits: 4
+      sizeBits: 8
       description: Remote MpsPermit
     #########################################################
     RemoteTimestamp:

--- a/firmware/targets/AmcCarrierLlrfBsaMpsMsgRx/Makefile
+++ b/firmware/targets/AmcCarrierLlrfBsaMpsMsgRx/Makefile
@@ -1,7 +1,7 @@
 ##########################################################################################
 # Applications must define the 32-bitFirmware Version Number
 ##########################################################################################
-export PRJ_VERSION = 0x02020000
+export PRJ_VERSION = 0x03000000
 
 ##########################################################################################
 # Applications must define if using advance AMC carrier build


### PR DESCRIPTION
### OLD MPS permit mapping
```
diagnosticBus.data(30)(03:00) = BSA_MPS_Link[0].mpsPermit[3:0]
diagnosticBus.data(30)(07:04) = BSA_MPS_Link[1].mpsPermit[3:0]
diagnosticBus.data(30)(11:08) = BSA_MPS_Link[2].mpsPermit[3:0]
diagnosticBus.data(30)(15:12) = BSA_MPS_Link[3].mpsPermit[3:0]
```

### NEW MPS permit mapping
```
# Link#0
diagnosticBus.data(30)(01:00) = BSA_MPS_Link[0].mpsPermit[0][1:0]
diagnosticBus.data(30)(03:02) = BSA_MPS_Link[0].mpsPermit[1][1:0]
diagnosticBus.data(30)(05:04) = BSA_MPS_Link[0].mpsPermit[2][1:0]
diagnosticBus.data(30)(07:06) = BSA_MPS_Link[0].mpsPermit[3][1:0]

# Link#1
diagnosticBus.data(30)(09:08) = BSA_MPS_Link[1].mpsPermit[0][1:0]
diagnosticBus.data(30)(11:10) = BSA_MPS_Link[1].mpsPermit[1][1:0]
diagnosticBus.data(30)(13:12) = BSA_MPS_Link[1].mpsPermit[2][1:0]
diagnosticBus.data(30)(15:14) = BSA_MPS_Link[1].mpsPermit[3][1:0]

# Link#2
diagnosticBus.data(30)(17:16) = BSA_MPS_Link[2].mpsPermit[0][1:0]
diagnosticBus.data(30)(19:18) = BSA_MPS_Link[2].mpsPermit[1][1:0]
diagnosticBus.data(30)(21:20) = BSA_MPS_Link[2].mpsPermit[2][1:0]
diagnosticBus.data(30)(23:22) = BSA_MPS_Link[2].mpsPermit[3][1:0]

# Link#3
diagnosticBus.data(30)(25:24) = BSA_MPS_Link[3].mpsPermit[0][1:0]
diagnosticBus.data(30)(27:26) = BSA_MPS_Link[3].mpsPermit[1][1:0]
diagnosticBus.data(30)(29:28) = BSA_MPS_Link[3].mpsPermit[2][1:0]
diagnosticBus.data(30)(31:30) = BSA_MPS_Link[3].mpsPermit[3][1:0]
```